### PR TITLE
Adding Flags & Some Fixes

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -39,6 +39,7 @@ def _main():
 
 def write_filterbanks(files,filname,total_length=0, raj = 123456.78, decj = -123456.78, name = None):
     from your.formats.filwriter import make_sigproc_object
+    cached_total_length = total_length
     for i,filename in enumerate(files):
         fbank= your.Your(filename)
         if i ==0:
@@ -65,7 +66,7 @@ def write_filterbanks(files,filname,total_length=0, raj = 123456.78, decj = -123
                                         za_start=-1
                                         )
             newdata.write_header(filname)
-        if total_length < 1:
+        if cached_total_length < 1:
                 total_length = fbank.nspec
         print(filename)
         totaldata=fbank.get_data(nstart=0,nsamp=total_length) ### TOTAL FAST DATA IS 1024 * 64 SUBINTS

--- a/merge.py
+++ b/merge.py
@@ -17,6 +17,7 @@ def _main():
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='Be verbose')
     parser.add_argument('-o', '--output', type=str, default="test", help='Output File Name')
     parser.add_argument('-N', '--segments', type=int, default=20, help='how many files per filterbank segment')
+    parser.add_argument('-s', '--samples-per-file', dest='samples', type=int, default=65536, help='Nubmer of time samples to read per input file, set to < 1 to read all data')
     parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ")
     parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ")
     parser.add_argument('-n', '--src', dest = 'src', default = "", type=str, help = "Source Name")
@@ -31,12 +32,12 @@ def _main():
     # print(values.files,fillength,inject_iter)
     for i in range(inject_iter):
         print(f"reading files {values.files[i*seg:(i+1)*seg]}, writing to {filname}_{i}.fil")
-        write_filterbanks(values.files[i*seg:(i+1)*seg],f"{filname}_{i}.fil",65536,values.ra,values.dec,values.src)
+        write_filterbanks(values.files[i*seg:(i+1)*seg],f"{filname}_{i}.fil",values.samples,values.ra,values.dec,values.src)
 
 
 
 
-def write_filterbanks(files,filname,total_length=65536, raj = 123456.78, decj = -123456.78, name = None):
+def write_filterbanks(files,filname,total_length=0, raj = 123456.78, decj = -123456.78, name = None):
     from your.formats.filwriter import make_sigproc_object
     for i,filename in enumerate(files):
         fbank= your.Your(filename)
@@ -64,7 +65,8 @@ def write_filterbanks(files,filname,total_length=65536, raj = 123456.78, decj = 
                                         za_start=-1
                                         )
             newdata.write_header(filname)
-
+        if total_length < 1:
+                total_length = fbank.nspec
         print(filename)
         totaldata=fbank.get_data(nstart=0,nsamp=total_length) ### TOTAL FAST DATA IS 1024 * 64 SUBINTS
         ### reads out stokes I data

--- a/merge.py
+++ b/merge.py
@@ -18,8 +18,8 @@ def _main():
     parser.add_argument('-o', '--output', type=str, default="test", help='Output File Name')
     parser.add_argument('-N', '--segments', type=int, default=20, help='how many files per filterbank segment')
     parser.add_argument('-s', '--samples-per-file', dest='samples', type=int, default=65536, help='Nubmer of time samples to read per input file, set to < 1 to read all data')
-    parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ")
-    parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ")
+    parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ (HHMMSS.sss)")
+    parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ (DDMMSS.sss")
     parser.add_argument('-n', '--src', dest = 'src', default = "", type=str, help = "Source Name")
 
     parser.add_argument(dest='files', nargs='+')

--- a/merge.py
+++ b/merge.py
@@ -4,6 +4,7 @@ script to connect filterbank files
 headers are automatically generated mock information, alter if necessary
 """
 import your
+import logging
 import numpy as np
 import os
 __author__ = "Harry Qiu"
@@ -73,6 +74,20 @@ def write_filterbanks(files,filname,total_length=0, raj = 123456.78, decj = -123
         ### reads out stokes I data
         ### this step reads all subints to merge into one datachunk, can't stop printing subint readouts
         newdata.append_spectra(totaldata.astype(np.int8),filname)
+
+# Silence the Polarization is AABB..." spam
+logger = logging.getLogger(your.formats.psrfits.__name__)
+class NoPolWarningFilter(logging.Filter):
+    parsed = False
+    def filter(self, record):
+        returnVal = record.getMessage().startswith('Polarization is ')
+        if returnVal:
+            if not self.parsed:
+                self.parsed = True
+            else:
+                return False
+        return True
+logger.addFilter(NoPolWarningFilter())
 
 if __name__ == '__main__':
     _main()

--- a/merge.py
+++ b/merge.py
@@ -15,9 +15,11 @@ def _main():
     from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
     parser = ArgumentParser(description='Script description', formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='Be verbose')
-    parser.add_argument('-o', '--output',type=str, default="test",help='Output File Name')
-    parser.add_argument('-N','--segments',type=int, default=20,help='how many files per filterbank segment')
-    # parser.add_argument('--nsamp',type=int, default=20,help='how many files per filterbank segment')
+    parser.add_argument('-o', '--output', type=str, default="test", help='Output File Name')
+    parser.add_argument('-N', '--segments', type=int, default=20, help='how many files per filterbank segment')
+    parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ")
+    parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ")
+    parser.add_argument('-n', '--src', dest = 'src', default = "", type=str, help = "Source Name")
 
     parser.add_argument(dest='files', nargs='+')
     parser.set_defaults(verbose=False)
@@ -29,27 +31,28 @@ def _main():
     # print(values.files,fillength,inject_iter)
     for i in range(inject_iter):
         print(f"reading files {values.files[i*seg:(i+1)*seg]}, writing to {filname}_{i}.fil")
-        write_filterbanks(files=values.files[i*seg:(i+1)*seg],filname=f"{filname}_{i}.fil")
+        write_filterbanks(values.files[i*seg:(i+1)*seg],f"{filname}_{i}.fil",65536,values.ra,values.dec,values.src)
 
 
 
 
-def write_filterbanks(files,filname,total_length=65536):
+def write_filterbanks(files,filname,total_length=65536, raj = 123456.78, decj = -123456.78, name = None):
     from your.formats.filwriter import make_sigproc_object
     for i,filename in enumerate(files):
         fbank= your.Your(filename)
         if i ==0:
             print()
             newdata=make_sigproc_object(rawdatafile=filname,
-                                        source_name = fbank.source_name.decode(),
+                                        telescope_id = 21, # FAST according to PRESTO
+                                        source_name = name or (fbank.source_name.decode() if isinstance(fbank.source_name, bytes) else fbank.source_name),
                                         nchans = fbank.nchans,
                                         foff = fbank.foff,
                                         fch1 = fbank.fch1,
-                                        tsamp =fbank.tsamp,
+                                        tsamp =fbank.native_tsamp,
                                         tstart = fbank.tstart,
                                         nbits=8,
-                                        src_raj=123456.78, # HHMMSS.SS
-                                        src_dej=-123456.78, # DDMMSS.SS
+                                        src_raj=raj, # HHMMSS.SS
+                                        src_dej=decj, # DDMMSS.SS
                                         machine_id=0,
                                         nbeams=1,
                                         ibeam=0,

--- a/scrunch.py
+++ b/scrunch.py
@@ -20,7 +20,9 @@ def _main():
     parser.add_argument('-c','--fbin',type=int, default=1,help='fscrunch channels per bin')
     parser.add_argument('-s','--samples',type=int, default=6553600,help='file sample length')
     parser.add_argument('-S','--seglen',type=int, default=1000,help='read in segment sample length factor, read in length is tbin*seglen')
-
+    parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ")
+    parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ")
+    parser.add_argument('-n', '--src', dest = 'src', default = "", type=str, help = "Source Name")
 
 
     ## your has not implemented this feature yet
@@ -31,14 +33,15 @@ def _main():
     filname=values.output
     fb= your.Your(values.file)
     newdata=make_sigproc_object(rawdatafile  = filname,
-                                source_name = fb.source_name.decode(),
+                                telescope_id = 21, # FAST according to PRESTO
+                                source_name = values.src or (fbank.source_name.decode() if isinstance(fbank.source_name, bytes) else fbank.source_name),
                                 nchans  = fb.nchans//values.fbin,
                                 foff = fb.foff*values.fbin, #MHz
                                 fch1 = fb.fch1, # MHz
-                                tsamp = fb.tsamp*values.tbin, # seconds
+                                tsamp = fb.native_tsamp*values.tbin, # seconds
                                 tstart = fb.tstart, #MJD
-                                src_raj=123456.78, # HHMMSS.SS
-                                src_dej=-123456.78, # DDMMSS.SS
+                                src_raj=raj, # HHMMSS.SS
+                                src_dej=decj, # DDMMSS.SS
                                 machine_id=0,
                                 nbeams=1,
                                 ibeam=0,

--- a/scrunch.py
+++ b/scrunch.py
@@ -20,8 +20,8 @@ def _main():
     parser.add_argument('-c','--fbin',type=int, default=1,help='fscrunch channels per bin')
     parser.add_argument('-s','--samples',type=int, default=6553600,help='file sample length')
     parser.add_argument('-S','--seglen',type=int, default=1000,help='read in segment sample length factor, read in length is tbin*seglen')
-    parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ")
-    parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ")
+    parser.add_argument('-r', '--ra', dest = 'ra', default = 123456.78, type=float, help = "Source RAJ (HHMMSS.sss)")
+    parser.add_argument('-d', '--dec', dest = 'dec', default = -123456.78, type=float, help = "Source RAJ (DDMMSS.sss")
     parser.add_argument('-n', '--src', dest = 'src', default = "", type=str, help = "Source Name")
 
 

--- a/scrunch.py
+++ b/scrunch.py
@@ -34,14 +34,14 @@ def _main():
     fb= your.Your(values.file)
     newdata=make_sigproc_object(rawdatafile  = filname,
                                 telescope_id = 21, # FAST according to PRESTO
-                                source_name = values.src or (fbank.source_name.decode() if isinstance(fbank.source_name, bytes) else fbank.source_name),
+                                source_name = values.src or (fb.source_name.decode() if isinstance(fb.source_name, bytes) else fb.source_name),
                                 nchans  = fb.nchans//values.fbin,
                                 foff = fb.foff*values.fbin, #MHz
                                 fch1 = fb.fch1, # MHz
                                 tsamp = fb.native_tsamp*values.tbin, # seconds
                                 tstart = fb.tstart, #MJD
-                                src_raj=raj, # HHMMSS.SS
-                                src_dej=decj, # DDMMSS.SS
+                                src_raj=values.ra, # HHMMSS.SS
+                                src_dej=values.dec, # DDMMSS.SS
                                 machine_id=0,
                                 nbeams=1,
                                 ibeam=0,


### PR DESCRIPTION
Hey Harry,

Took me a while, but I've finally got around to looking at our FAST data, here are a few tweaks I made to your scripts that might be useful for you too

In terms of a list of changes:
- Added RA, Dec and source name flags
- Added a telescope_id for the outputs, based on the current ID for FAST in PRESTO[0]
- Moved some `fbank` variables over to their native values (as otherwise your was raising errors for me)
- `fbank.source_name` seems to be a string for me, so I added an if/else statement to only decode the default as needed
- Added an option to vary the number of samples read from each file, since I had a different number of samples to your default

Cheers,
David

[0] https://github.com/scottransom/presto/blob/010e1c1c0e735558d5b8afb77a24e548a008f756/python/presto/sigproc.py#L16